### PR TITLE
Retry downloads that fail on copying from S3

### DIFF
--- a/cmd/pivnet/commands/productfile/product_file_client.go
+++ b/cmd/pivnet/commands/productfile/product_file_client.go
@@ -435,11 +435,6 @@ func (c *ProductFileClient) Download(
 		}
 	}
 
-	progress := newProgressBar(productFile.Size, c.logWriter)
-	onDemandProgress := &startOnDemandProgressBar{progress, false}
-
-	multiWriter := io.MultiWriter(file, onDemandProgress)
-
 	c.l.Debug(
 		"Downloading link to local file",
 		logger.Data{
@@ -447,13 +442,36 @@ func (c *ProductFileClient) Download(
 			"localFilepath": filepath,
 		},
 	)
-	err, _ = c.pivnetClient.DownloadFile(multiWriter, downloadLink)
-	if err != nil {
-		return c.eh.HandleError(err)
+
+	for i := 3; i > 0; i-- {
+		progress := newProgressBar(productFile.Size, c.logWriter)
+		onDemandProgress := &startOnDemandProgressBar{progress, false}
+
+		multiWriter := io.MultiWriter(file, onDemandProgress)
+
+		var retryable bool
+		err, retryable = c.pivnetClient.DownloadFile(multiWriter, downloadLink)
+
+		if err != nil && retryable {
+			c.l.Debug(
+				fmt.Sprintf("Download failed; retrying... (%d attempt(s) left)", i),
+				logger.Data{
+					"Error": err,
+				},
+			)
+
+			continue
+		}
+
+		if err != nil {
+			break
+		}
+
+		progress.Finish()
+		return nil
 	}
 
-	progress.Finish()
-	return nil
+	return c.eh.HandleError(err)
 }
 
 type startOnDemandProgressBar struct {

--- a/cmd/pivnet/commands/productfile/product_file_client.go
+++ b/cmd/pivnet/commands/productfile/product_file_client.go
@@ -29,7 +29,7 @@ type PivnetClient interface {
 	RemoveProductFileFromFileGroup(productSlug string, fileGroupID int, productFileID int) error
 	DeleteProductFile(productSlug string, releaseID int) (pivnet.ProductFile, error)
 	AcceptEULA(productSlug string, releaseID int) error
-	DownloadFile(writer io.Writer, downloadLink string) error
+	DownloadFile(writer io.Writer, downloadLink string) (err error, retryable bool)
 }
 
 type ProductFileClient struct {
@@ -447,7 +447,7 @@ func (c *ProductFileClient) Download(
 			"localFilepath": filepath,
 		},
 	)
-	err = c.pivnetClient.DownloadFile(multiWriter, downloadLink)
+	err, _ = c.pivnetClient.DownloadFile(multiWriter, downloadLink)
 	if err != nil {
 		return c.eh.HandleError(err)
 	}

--- a/cmd/pivnet/commands/productfile/product_file_client_test.go
+++ b/cmd/pivnet/commands/productfile/product_file_client_test.go
@@ -715,7 +715,7 @@ var _ = Describe("productfile commands", func() {
 			Expect(contents).To(Equal([]byte(fileContents)))
 		})
 
-		Context("when there is an error", func() {
+		Context("when there is a non-retryable error", func() {
 			var (
 				expectedErr error
 			)
@@ -738,6 +738,64 @@ var _ = Describe("productfile commands", func() {
 				Expect(fakeErrorHandler.HandleErrorCallCount()).To(Equal(1))
 				Expect(fakeErrorHandler.HandleErrorArgsForCall(0)).To(Equal(expectedErr))
 			})
+		})
+
+		Context("when there is a retryable error", func() {
+			var (
+				expectedErr error
+				triesCount  int
+			)
+
+			BeforeEach(func() {
+				expectedErr = errors.New("productfile error")
+				triesCount = 0
+				fakePivnetClient.DownloadFileStub = func(writer io.Writer, downloadLink string) (err error, retryable bool) {
+					failed := (triesCount < 1)
+					triesCount++
+
+					if failed {
+						return expectedErr, true
+					} else {
+						return nil, true
+					}
+				}
+			})
+
+			It("retries the download", func() {
+				err := client.Download(
+					productSlug,
+					releaseVersion,
+					productFileID,
+					providedFilepath,
+					acceptEULA,
+				)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fakePivnetClient.DownloadFileCallCount()).To(Equal(2))
+				Expect(fakeErrorHandler.HandleErrorCallCount()).To(Equal(0))
+			})
+
+			Context("when the error has occurred three times", func() {
+				BeforeEach(func() {
+					fakePivnetClient.DownloadFileReturns(expectedErr, true)
+				})
+
+				It("invokes the error handler", func() {
+					err := client.Download(
+						productSlug,
+						releaseVersion,
+						productFileID,
+						providedFilepath,
+						acceptEULA,
+					)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(fakePivnetClient.DownloadFileCallCount()).To(Equal(3))
+					Expect(fakeErrorHandler.HandleErrorCallCount()).To(Equal(1))
+					Expect(fakeErrorHandler.HandleErrorArgsForCall(0)).To(Equal(expectedErr))
+				})
+			})
+
 		})
 
 		Context("when there is an error getting release", func() {

--- a/cmd/pivnet/commands/productfile/product_file_client_test.go
+++ b/cmd/pivnet/commands/productfile/product_file_client_test.go
@@ -678,9 +678,9 @@ var _ = Describe("productfile commands", func() {
 			}
 
 			fakePivnetClient.ReleaseForVersionReturns(returnedRelease, nil)
-			fakePivnetClient.DownloadFileStub = func(writer io.Writer, downloadLink string) error {
-				_, err := fmt.Fprintf(writer, fileContents)
-				return err
+			fakePivnetClient.DownloadFileStub = func(writer io.Writer, downloadLink string) (err error, retryable bool) {
+				_, err = fmt.Fprintf(writer, fileContents)
+				return err, false
 			}
 		})
 
@@ -722,7 +722,7 @@ var _ = Describe("productfile commands", func() {
 
 			BeforeEach(func() {
 				expectedErr = errors.New("productfile error")
-				fakePivnetClient.DownloadFileReturns(expectedErr)
+				fakePivnetClient.DownloadFileReturns(expectedErr, false)
 			})
 
 			It("invokes the error handler", func() {

--- a/cmd/pivnet/commands/productfile/productfilefakes/fake_pivnet_client.go
+++ b/cmd/pivnet/commands/productfile/productfilefakes/fake_pivnet_client.go
@@ -138,7 +138,7 @@ type FakePivnetClient struct {
 	acceptEULAReturns struct {
 		result1 error
 	}
-	DownloadFileStub        func(writer io.Writer, downloadLink string) error
+	DownloadFileStub        func(writer io.Writer, downloadLink string) (err error, retryable bool)
 	downloadFileMutex       sync.RWMutex
 	downloadFileArgsForCall []struct {
 		writer       io.Writer
@@ -146,6 +146,7 @@ type FakePivnetClient struct {
 	}
 	downloadFileReturns struct {
 		result1 error
+		result2 bool
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
@@ -604,7 +605,7 @@ func (fake *FakePivnetClient) AcceptEULAReturns(result1 error) {
 	}{result1}
 }
 
-func (fake *FakePivnetClient) DownloadFile(writer io.Writer, downloadLink string) error {
+func (fake *FakePivnetClient) DownloadFile(writer io.Writer, downloadLink string) (err error, retryable bool) {
 	fake.downloadFileMutex.Lock()
 	fake.downloadFileArgsForCall = append(fake.downloadFileArgsForCall, struct {
 		writer       io.Writer
@@ -615,7 +616,7 @@ func (fake *FakePivnetClient) DownloadFile(writer io.Writer, downloadLink string
 	if fake.DownloadFileStub != nil {
 		return fake.DownloadFileStub(writer, downloadLink)
 	} else {
-		return fake.downloadFileReturns.result1
+		return fake.downloadFileReturns.result1, fake.downloadFileReturns.result2
 	}
 }
 
@@ -631,11 +632,12 @@ func (fake *FakePivnetClient) DownloadFileArgsForCall(i int) (io.Writer, string)
 	return fake.downloadFileArgsForCall[i].writer, fake.downloadFileArgsForCall[i].downloadLink
 }
 
-func (fake *FakePivnetClient) DownloadFileReturns(result1 error) {
+func (fake *FakePivnetClient) DownloadFileReturns(result1 error, result2 bool) {
 	fake.DownloadFileStub = nil
 	fake.downloadFileReturns = struct {
 		result1 error
-	}{result1}
+		result2 bool
+	}{result1, result2}
 }
 
 func (fake *FakePivnetClient) Invocations() map[string][][]interface{} {

--- a/cmd/pivnet/gp/gp.go
+++ b/cmd/pivnet/gp/gp.go
@@ -267,6 +267,6 @@ func (c ExtendedClient) ReleaseFingerprint(productSlug string, releaseID int) (s
 	return c.client.ReleaseFingerprint(productSlug, releaseID)
 }
 
-func (c ExtendedClient) DownloadFile(writer io.Writer, downloadLink string) error {
+func (c ExtendedClient) DownloadFile(writer io.Writer, downloadLink string) (err error, retryable bool) {
 	return c.client.DownloadFile(writer, downloadLink)
 }

--- a/extension/extended_client_test.go
+++ b/extension/extended_client_test.go
@@ -287,8 +287,9 @@ var _ = Describe("ExtendedClient", func() {
 		It("writes file contents to provided writer", func() {
 			writer := bytes.NewBuffer(nil)
 
-			err := client.DownloadFile(writer, downloadLink)
+			err, retryable := client.DownloadFile(writer, downloadLink)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(retryable).To(BeTrue())
 
 			Expect(writer.Bytes()).To(Equal(fileContents))
 		})
@@ -307,8 +308,13 @@ var _ = Describe("ExtendedClient", func() {
 			})
 
 			It("forwards the error", func() {
-				err := client.DownloadFile(nil, downloadLink)
+				err, _ := client.DownloadFile(nil, downloadLink)
 				Expect(err).To(Equal(expectedErr))
+			})
+
+			It("is not retryable", func() {
+				_, retryable := client.DownloadFile(nil, downloadLink)
+				Expect(retryable).To(BeFalse())
 			})
 		})
 
@@ -328,8 +334,13 @@ var _ = Describe("ExtendedClient", func() {
 			})
 
 			It("forwards the error", func() {
-				err := client.DownloadFile(nil, downloadLink)
+				err, _ := client.DownloadFile(nil, downloadLink)
 				Expect(err).To(HaveOccurred())
+			})
+
+			It("is not retryable", func() {
+				_, retryable := client.DownloadFile(nil, downloadLink)
+				Expect(retryable).To(BeFalse())
 			})
 		})
 
@@ -350,8 +361,13 @@ var _ = Describe("ExtendedClient", func() {
 			})
 
 			It("forwards the error", func() {
-				err := client.DownloadFile(nil, downloadLink)
+				err, _ := client.DownloadFile(nil, downloadLink)
 				Expect(err).To(HaveOccurred())
+			})
+
+			It("is not retryable", func() {
+				_, retryable := client.DownloadFile(nil, downloadLink)
+				Expect(retryable).To(BeFalse())
 			})
 		})
 
@@ -361,10 +377,15 @@ var _ = Describe("ExtendedClient", func() {
 			})
 
 			It("returns an error", func() {
-				err := client.DownloadFile(nil, downloadLink)
+				err, _ := client.DownloadFile(nil, downloadLink)
 				Expect(err).To(HaveOccurred())
 
 				Expect(err.Error()).To(ContainSubstring("EULA"))
+			})
+
+			It("is not retryable", func() {
+				_, retryable := client.DownloadFile(nil, downloadLink)
+				Expect(retryable).To(BeFalse())
 			})
 		})
 
@@ -374,10 +395,15 @@ var _ = Describe("ExtendedClient", func() {
 			})
 
 			It("returns an error", func() {
-				err := client.DownloadFile(nil, downloadLink)
+				err, _ := client.DownloadFile(nil, downloadLink)
 				Expect(err).To(HaveOccurred())
 
 				Expect(err.Error()).To(ContainSubstring("418"))
+			})
+
+			It("is not retryable", func() {
+				_, retryable := client.DownloadFile(nil, downloadLink)
+				Expect(retryable).To(BeFalse())
 			})
 		})
 
@@ -391,10 +417,15 @@ var _ = Describe("ExtendedClient", func() {
 			})
 
 			It("returns an error", func() {
-				err := client.DownloadFile(writer, downloadLink)
+				err, _ := client.DownloadFile(writer, downloadLink)
 				Expect(err).To(HaveOccurred())
 
 				Expect(err.Error()).To(ContainSubstring("error writing"))
+			})
+
+			It("is retryable", func() {
+				_, retryable := client.DownloadFile(writer, downloadLink)
+				Expect(retryable).To(BeTrue())
 			})
 		})
 	})


### PR DESCRIPTION
Hiya!

These commits are the go-pivnet side of https://github.com/pivotal-cf/pivnet-resource/issues/38. They:

1. Change the `ExtendedClient#DownloadFile` method signature and behavior to return a `retryable` boolean, which is `false` in all cases except for a failed `io.Copy` and a successful download.
2. Update the pivnet CLI to retry the `DownloadFile` method if it fails with a `retryable` value of `true`. If any `DownloadFile` calls fail with a false `retryable` value, or if downloads fail three times, the error is passed to the error handler as before.

If merged, I can work on introducing the same behavior to the pivnet-resource.

- Have you made this pull request to the `develop` branch?
Yes.

- Have you [run the tests locally](https://github.com/pivotal-cf/go-pivnet#running-the-tests)?
Yes.