### PR TITLE
MakeRequest does not parse response body

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -9,17 +9,16 @@ type AuthService struct {
 func (e AuthService) Check() error {
 	url := "/authentication"
 
-	var response EULAsResponse
-	_, _, err := e.client.MakeRequest(
+	resp, err := e.client.MakeRequest(
 		"GET",
 		url,
 		http.StatusOK,
 		nil,
-		&response,
 	)
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	return nil
 }

--- a/eulas.go
+++ b/eulas.go
@@ -1,6 +1,7 @@
 package pivnet
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -32,13 +33,18 @@ func (e EULAsService) List() ([]EULA, error) {
 	url := "/eulas"
 
 	var response EULAsResponse
-	_, _, err := e.client.MakeRequest(
+	resp, err := e.client.MakeRequest(
 		"GET",
 		url,
 		http.StatusOK,
 		nil,
-		&response,
 	)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return nil, err
 	}
@@ -50,13 +56,18 @@ func (e EULAsService) Get(eulaSlug string) (EULA, error) {
 	url := fmt.Sprintf("/eulas/%s", eulaSlug)
 
 	var response EULA
-	_, _, err := e.client.MakeRequest(
+	resp, err := e.client.MakeRequest(
 		"GET",
 		url,
 		http.StatusOK,
 		nil,
-		&response,
 	)
+	if err != nil {
+		return EULA{}, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return EULA{}, err
 	}
@@ -71,17 +82,16 @@ func (e EULAsService) Accept(productSlug string, releaseID int) error {
 		releaseID,
 	)
 
-	var response EULAAcceptanceResponse
-	_, _, err := e.client.MakeRequest(
+	resp, err := e.client.MakeRequest(
 		"POST",
 		url,
 		http.StatusOK,
 		strings.NewReader(`{}`),
-		&response,
 	)
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	return nil
 }

--- a/file_groups.go
+++ b/file_groups.go
@@ -47,13 +47,18 @@ func (e FileGroupsService) List(productSlug string) ([]FileGroup, error) {
 	url := fmt.Sprintf("/products/%s/file_groups", productSlug)
 
 	var response FileGroupsResponse
-	_, _, err := e.client.MakeRequest(
+	resp, err := e.client.MakeRequest(
 		"GET",
 		url,
 		http.StatusOK,
 		nil,
-		&response,
 	)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return nil, err
 	}
@@ -68,13 +73,18 @@ func (p FileGroupsService) Get(productSlug string, fileGroupID int) (FileGroup, 
 	)
 
 	var response FileGroup
-	_, _, err := p.client.MakeRequest(
+	resp, err := p.client.MakeRequest(
 		"GET",
 		url,
 		http.StatusOK,
 		nil,
-		&response,
 	)
+	if err != nil {
+		return FileGroup{}, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return FileGroup{}, err
 	}
@@ -104,13 +114,18 @@ func (p FileGroupsService) Create(productSlug string, name string) (FileGroup, e
 	body := bytes.NewReader(b)
 
 	var response FileGroup
-	_, _, err = p.client.MakeRequest(
+	resp, err := p.client.MakeRequest(
 		"POST",
 		url,
 		http.StatusCreated,
 		body,
-		&response,
 	)
+	if err != nil {
+		return FileGroup{}, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return FileGroup{}, err
 	}
@@ -141,13 +156,18 @@ func (p FileGroupsService) Update(productSlug string, fileGroup FileGroup) (File
 	body := bytes.NewReader(b)
 
 	var response FileGroup
-	_, _, err = p.client.MakeRequest(
+	resp, err := p.client.MakeRequest(
 		"PATCH",
 		url,
 		http.StatusOK,
 		body,
-		&response,
 	)
+	if err != nil {
+		return FileGroup{}, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return FileGroup{}, err
 	}
@@ -163,13 +183,18 @@ func (p FileGroupsService) Delete(productSlug string, id int) (FileGroup, error)
 	)
 
 	var response FileGroup
-	_, _, err := p.client.MakeRequest(
+	resp, err := p.client.MakeRequest(
 		"DELETE",
 		url,
 		http.StatusOK,
 		nil,
-		&response,
 	)
+	if err != nil {
+		return FileGroup{}, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return FileGroup{}, err
 	}
@@ -184,13 +209,18 @@ func (p FileGroupsService) ListForRelease(productSlug string, releaseID int) ([]
 	)
 
 	var response FileGroupsResponse
-	_, _, err := p.client.MakeRequest(
+	resp, err := p.client.MakeRequest(
 		"GET",
 		url,
 		http.StatusOK,
 		nil,
-		&response,
 	)
+	if err != nil {
+		return []FileGroup{}, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return []FileGroup{}, err
 	}
@@ -222,16 +252,16 @@ func (r FileGroupsService) AddToRelease(
 		return err
 	}
 
-	_, _, err = r.client.MakeRequest(
+	resp, err := r.client.MakeRequest(
 		"PATCH",
 		url,
 		http.StatusNoContent,
 		bytes.NewReader(b),
-		nil,
 	)
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	return nil
 }
@@ -260,16 +290,16 @@ func (r FileGroupsService) RemoveFromRelease(
 		return err
 	}
 
-	_, _, err = r.client.MakeRequest(
+	resp, err := r.client.MakeRequest(
 		"PATCH",
 		url,
 		http.StatusNoContent,
 		bytes.NewReader(b),
-		nil,
 	)
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	return nil
 }

--- a/pivnet_test.go
+++ b/pivnet_test.go
@@ -71,11 +71,10 @@ var _ = Describe("PivnetClient", func() {
 			),
 		)
 
-		_, _, err := client.MakeRequest(
+		_, err := client.MakeRequest(
 			"GET",
 			"/foo",
 			http.StatusOK,
-			nil,
 			nil,
 		)
 		Expect(err).NotTo(HaveOccurred())
@@ -94,11 +93,10 @@ var _ = Describe("PivnetClient", func() {
 			),
 		)
 
-		_, _, err := client.MakeRequest(
+		_, err := client.MakeRequest(
 			"GET",
 			"/foo",
 			http.StatusOK,
-			nil,
 			nil,
 		)
 		Expect(err).NotTo(HaveOccurred())
@@ -116,11 +114,10 @@ var _ = Describe("PivnetClient", func() {
 			),
 		)
 
-		_, _, err := client.MakeRequest(
+		_, err := client.MakeRequest(
 			"GET",
 			"/foo",
 			http.StatusOK,
-			nil,
 			nil,
 		)
 		Expect(err).NotTo(HaveOccurred())
@@ -131,11 +128,10 @@ var _ = Describe("PivnetClient", func() {
 			newClientConfig.Host = "%%%"
 			client = pivnet.NewClient(newClientConfig, fakeLogger)
 
-			_, _, err := client.MakeRequest(
+			_, err := client.MakeRequest(
 				"GET",
 				"/foo",
 				http.StatusOK,
-				nil,
 				nil,
 			)
 			Expect(err).To(HaveOccurred())
@@ -148,11 +144,10 @@ var _ = Describe("PivnetClient", func() {
 			newClientConfig.Host = "https://not-a-real-url.com"
 			client = pivnet.NewClient(newClientConfig, fakeLogger)
 
-			_, _, err := client.MakeRequest(
+			_, err := client.MakeRequest(
 				"GET",
 				"/foo",
 				http.StatusOK,
-				nil,
 				nil,
 			)
 			Expect(err).To(HaveOccurred())
@@ -179,11 +174,10 @@ var _ = Describe("PivnetClient", func() {
 				),
 			)
 
-			_, _, err := client.MakeRequest(
+			_, err := client.MakeRequest(
 				"GET",
 				"/foo",
 				http.StatusOK,
-				nil,
 				nil,
 			)
 			Expect(err).To(HaveOccurred())
@@ -216,11 +210,10 @@ var _ = Describe("PivnetClient", func() {
 				),
 			)
 
-			_, _, err := client.MakeRequest(
+			_, err := client.MakeRequest(
 				"GET",
 				"/foo",
 				http.StatusOK,
-				nil,
 				nil,
 			)
 			Expect(err).To(HaveOccurred())
@@ -253,11 +246,10 @@ var _ = Describe("PivnetClient", func() {
 				),
 			)
 
-			_, _, err := client.MakeRequest(
+			_, err := client.MakeRequest(
 				"GET",
 				"/foo",
 				http.StatusOK,
-				nil,
 				nil,
 			)
 			Expect(err).To(HaveOccurred())
@@ -290,11 +282,10 @@ var _ = Describe("PivnetClient", func() {
 				),
 			)
 
-			_, _, err := client.MakeRequest(
+			_, err := client.MakeRequest(
 				"GET",
 				"/foo",
 				http.StatusOK,
-				nil,
 				nil,
 			)
 			Expect(err).To(HaveOccurred())
@@ -322,11 +313,10 @@ var _ = Describe("PivnetClient", func() {
 					),
 				)
 
-				_, _, err := client.MakeRequest(
+				_, err := client.MakeRequest(
 					"GET",
 					"/foo",
 					http.StatusOK,
-					nil,
 					nil,
 				)
 				Expect(err).To(HaveOccurred())
@@ -355,11 +345,10 @@ var _ = Describe("PivnetClient", func() {
 				),
 			)
 
-			_, _, err := client.MakeRequest(
+			_, err := client.MakeRequest(
 				"GET",
 				"/foo",
 				http.StatusOK,
-				nil,
 				nil,
 			)
 			Expect(err).To(HaveOccurred())
@@ -378,11 +367,10 @@ var _ = Describe("PivnetClient", func() {
 					),
 				)
 
-				_, _, err := client.MakeRequest(
+				_, err := client.MakeRequest(
 					"GET",
 					"/foo",
 					http.StatusOK,
-					nil,
 					nil,
 				)
 				Expect(err).To(HaveOccurred())
@@ -402,61 +390,16 @@ var _ = Describe("PivnetClient", func() {
 					),
 				)
 
-				_, _, err := client.MakeRequest(
+				_, err := client.MakeRequest(
 					"GET",
 					"/foo",
 					0,
-					nil,
 					nil,
 				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
 
-	})
-
-	Context("when the json unmarshalling fails with error", func() {
-		It("forwards the error", func() {
-			server.AppendHandlers(
-				ghttp.CombineHandlers(
-					ghttp.VerifyRequest(
-						"GET",
-						fmt.Sprintf("%s/foo", apiPrefix),
-					),
-					ghttp.RespondWith(http.StatusOK, "%%%"),
-				),
-			)
-
-			_, _, err := client.MakeRequest(
-				"GET",
-				"/foo",
-				http.StatusOK,
-				nil,
-				struct{}{},
-			)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("invalid character"))
-		})
-	})
-
-	Context("when nil interface is provided for deserialization", func() {
-		It("skips deserialization", func() {
-			server.AppendHandlers(
-				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", fmt.Sprintf("%s/some/endpoint", apiPrefix)),
-					ghttp.RespondWith(http.StatusOK, "{}"),
-				),
-			)
-
-			_, _, err := client.MakeRequest(
-				"GET",
-				"/some/endpoint",
-				http.StatusOK,
-				nil,
-				nil,
-			)
-			Expect(err).NotTo(HaveOccurred())
-		})
 	})
 
 	Describe("CreateRequest", func() {

--- a/product_files.go
+++ b/product_files.go
@@ -75,13 +75,18 @@ func (p ProductFilesService) List(productSlug string) ([]ProductFile, error) {
 	url := fmt.Sprintf("/products/%s/product_files", productSlug)
 
 	var response ProductFilesResponse
-	_, _, err := p.client.MakeRequest(
+	resp, err := p.client.MakeRequest(
 		"GET",
 		url,
 		http.StatusOK,
 		nil,
-		&response,
 	)
+	if err != nil {
+		return []ProductFile{}, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return []ProductFile{}, err
 	}
@@ -97,13 +102,18 @@ func (p ProductFilesService) ListForRelease(productSlug string, releaseID int) (
 	)
 
 	var response ProductFilesResponse
-	_, _, err := p.client.MakeRequest(
+	resp, err := p.client.MakeRequest(
 		"GET",
 		url,
 		http.StatusOK,
 		nil,
-		&response,
 	)
+	if err != nil {
+		return []ProductFile{}, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return []ProductFile{}, err
 	}
@@ -119,13 +129,18 @@ func (p ProductFilesService) Get(productSlug string, productFileID int) (Product
 	)
 
 	var response ProductFileResponse
-	_, _, err := p.client.MakeRequest(
+	resp, err := p.client.MakeRequest(
 		"GET",
 		url,
 		http.StatusOK,
 		nil,
-		&response,
 	)
+	if err != nil {
+		return ProductFile{}, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return ProductFile{}, err
 	}
@@ -142,13 +157,18 @@ func (p ProductFilesService) GetForRelease(productSlug string, releaseID int, pr
 	)
 
 	var response ProductFileResponse
-	_, _, err := p.client.MakeRequest(
+	resp, err := p.client.MakeRequest(
 		"GET",
 		url,
 		http.StatusOK,
 		nil,
-		&response,
 	)
+	if err != nil {
+		return ProductFile{}, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return ProductFile{}, err
 	}
@@ -187,13 +207,18 @@ func (p ProductFilesService) Create(config CreateProductFileConfig) (ProductFile
 	}
 
 	var response ProductFileResponse
-	_, _, err = p.client.MakeRequest(
+	resp, err := p.client.MakeRequest(
 		"POST",
 		url,
 		http.StatusCreated,
 		bytes.NewReader(b),
-		&response,
 	)
+	if err != nil {
+		return ProductFile{}, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return ProductFile{}, err
 	}
@@ -222,13 +247,18 @@ func (p ProductFilesService) Update(productSlug string, productFile ProductFile)
 	}
 
 	var response ProductFileResponse
-	_, _, err = p.client.MakeRequest(
+	resp, err := p.client.MakeRequest(
 		"PATCH",
 		url,
 		http.StatusOK,
 		bytes.NewReader(b),
-		&response,
 	)
+	if err != nil {
+		return ProductFile{}, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return ProductFile{}, err
 	}
@@ -248,13 +278,18 @@ func (p ProductFilesService) Delete(productSlug string, id int) (ProductFile, er
 	)
 
 	var response ProductFileResponse
-	_, _, err := p.client.MakeRequest(
+	resp, err := p.client.MakeRequest(
 		"DELETE",
 		url,
 		http.StatusOK,
 		nil,
-		&response,
 	)
+	if err != nil {
+		return ProductFile{}, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return ProductFile{}, err
 	}
@@ -286,16 +321,16 @@ func (p ProductFilesService) AddToRelease(
 		return err
 	}
 
-	_, _, err = p.client.MakeRequest(
+	resp, err := p.client.MakeRequest(
 		"PATCH",
 		url,
 		http.StatusNoContent,
 		bytes.NewReader(b),
-		nil,
 	)
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	return nil
 }
@@ -324,16 +359,16 @@ func (p ProductFilesService) RemoveFromRelease(
 		return err
 	}
 
-	_, _, err = p.client.MakeRequest(
+	resp, err := p.client.MakeRequest(
 		"PATCH",
 		url,
 		http.StatusNoContent,
 		bytes.NewReader(b),
-		nil,
 	)
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	return nil
 }
@@ -362,16 +397,16 @@ func (p ProductFilesService) AddToFileGroup(
 		return err
 	}
 
-	_, _, err = p.client.MakeRequest(
+	resp, err := p.client.MakeRequest(
 		"PATCH",
 		url,
 		http.StatusNoContent,
 		bytes.NewReader(b),
-		nil,
 	)
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	return nil
 }
@@ -400,16 +435,16 @@ func (p ProductFilesService) RemoveFromFileGroup(
 		return err
 	}
 
-	_, _, err = p.client.MakeRequest(
+	resp, err := p.client.MakeRequest(
 		"PATCH",
 		url,
 		http.StatusNoContent,
 		bytes.NewReader(b),
-		nil,
 	)
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	return nil
 }
@@ -436,21 +471,21 @@ func (p ProductFilesService) DownloadForRelease(
 
 	p.client.logger.Debug("Downloading file", logger.Data{"downloadLink": downloadLink})
 
-	_, body, err := p.client.MakeRequest(
+	resp, err := p.client.MakeRequest(
 		"POST",
 		downloadLink,
 		http.StatusOK,
-		nil,
 		nil,
 	)
 	if err != nil {
 		// Untested as we cannot force CreateRequest to return an error.
 		return err
 	}
+	defer resp.Body.Close()
 
 	p.client.logger.Debug("Copying body", logger.Data{"downloadLink": downloadLink})
 
-	_, err = io.Copy(writer, bytes.NewReader(body))
+	_, err = io.Copy(writer, resp.Body)
 	if err != nil {
 		return err
 	}

--- a/products.go
+++ b/products.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/pivotal-cf/go-pivnet/logger"
+	"encoding/json"
 )
 
 type ProductsService struct {
@@ -26,13 +27,18 @@ func (p ProductsService) List() ([]Product, error) {
 	url := "/products"
 
 	var response ProductsResponse
-	_, _, err := p.client.MakeRequest(
+	resp, err := p.client.MakeRequest(
 		"GET",
 		url,
 		http.StatusOK,
 		nil,
-		&response,
 	)
+	if err != nil {
+		return []Product{}, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return []Product{}, err
 	}
@@ -44,13 +50,18 @@ func (p ProductsService) Get(slug string) (Product, error) {
 	url := fmt.Sprintf("/products/%s", slug)
 
 	var response Product
-	_, _, err := p.client.MakeRequest(
+	resp, err := p.client.MakeRequest(
 		"GET",
 		url,
 		http.StatusOK,
 		nil,
-		&response,
 	)
+	if err != nil {
+		return Product{}, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return Product{}, err
 	}

--- a/release_dependencies.go
+++ b/release_dependencies.go
@@ -33,13 +33,18 @@ func (r ReleaseDependenciesService) List(productSlug string, releaseID int) ([]R
 	)
 
 	var response ReleaseDependenciesResponse
-	_, _, err := r.client.MakeRequest(
+	resp, err := r.client.MakeRequest(
 		"GET",
 		url,
 		http.StatusOK,
 		nil,
-		&response,
 	)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return nil, err
 	}
@@ -71,16 +76,16 @@ func (r ReleaseDependenciesService) Add(
 		return err
 	}
 
-	_, _, err = r.client.MakeRequest(
+	resp, err := r.client.MakeRequest(
 		"PATCH",
 		url,
 		http.StatusNoContent,
 		bytes.NewReader(b),
-		nil,
 	)
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	return nil
 }
@@ -109,16 +114,16 @@ func (r ReleaseDependenciesService) Remove(
 		return err
 	}
 
-	_, _, err = r.client.MakeRequest(
+	resp, err := r.client.MakeRequest(
 		"PATCH",
 		url,
 		http.StatusNoContent,
 		bytes.NewReader(b),
-		nil,
 	)
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	return nil
 }

--- a/release_types.go
+++ b/release_types.go
@@ -3,6 +3,7 @@ package pivnet
 import (
 	"fmt"
 	"net/http"
+	"encoding/json"
 )
 
 type ReleaseTypesService struct {
@@ -19,13 +20,18 @@ func (r ReleaseTypesService) Get() ([]ReleaseType, error) {
 	url := fmt.Sprintf("/releases/release_types")
 
 	var response ReleaseTypesResponse
-	_, _, err := r.client.MakeRequest(
+	resp, err := r.client.MakeRequest(
 		"GET",
 		url,
 		http.StatusOK,
 		nil,
-		&response,
 	)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return nil, err
 	}

--- a/release_upgrade_paths.go
+++ b/release_upgrade_paths.go
@@ -32,13 +32,18 @@ func (r ReleaseUpgradePathsService) Get(productSlug string, releaseID int) ([]Re
 	)
 
 	var response ReleaseUpgradePathsResponse
-	_, _, err := r.client.MakeRequest(
+	resp, err := r.client.MakeRequest(
 		"GET",
 		url,
 		http.StatusOK,
 		nil,
-		&response,
 	)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return nil, err
 	}
@@ -70,16 +75,16 @@ func (r ReleaseUpgradePathsService) Add(
 		return err
 	}
 
-	_, _, err = r.client.MakeRequest(
+	resp, err := r.client.MakeRequest(
 		"PATCH",
 		url,
 		http.StatusNoContent,
 		bytes.NewReader(b),
-		nil,
 	)
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	return nil
 }
@@ -108,16 +113,16 @@ func (r ReleaseUpgradePathsService) Remove(
 		return err
 	}
 
-	_, _, err = r.client.MakeRequest(
+	resp, err := r.client.MakeRequest(
 		"PATCH",
 		url,
 		http.StatusNoContent,
 		bytes.NewReader(b),
-		nil,
 	)
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	return nil
 }

--- a/releases.go
+++ b/releases.go
@@ -67,7 +67,13 @@ func (r ReleasesService) List(productSlug string) ([]Release, error) {
 	url := fmt.Sprintf("/products/%s/releases", productSlug)
 
 	var response ReleasesResponse
-	_, _, err := r.client.MakeRequest("GET", url, http.StatusOK, nil, &response)
+	resp, err := r.client.MakeRequest("GET", url, http.StatusOK, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +85,13 @@ func (r ReleasesService) Get(productSlug string, releaseID int) (Release, error)
 	url := fmt.Sprintf("/products/%s/releases/%d", productSlug, releaseID)
 
 	var response Release
-	_, _, err := r.client.MakeRequest("GET", url, http.StatusOK, nil, &response)
+	resp, err := r.client.MakeRequest("GET", url, http.StatusOK, nil)
+	if err != nil {
+		return Release{}, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return Release{}, err
 	}
@@ -126,13 +138,18 @@ func (r ReleasesService) Create(config CreateReleaseConfig) (Release, error) {
 	}
 
 	var response CreateReleaseResponse
-	_, _, err = r.client.MakeRequest(
+	resp, err := r.client.MakeRequest(
 		"POST",
 		url,
 		http.StatusCreated,
 		bytes.NewReader(b),
-		&response,
 	)
+	if err != nil {
+		return Release{}, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return Release{}, err
 	}
@@ -161,13 +178,18 @@ func (r ReleasesService) Update(productSlug string, release Release) (Release, e
 	}
 
 	var response CreateReleaseResponse
-	_, _, err = r.client.MakeRequest(
+	resp, err := r.client.MakeRequest(
 		"PATCH",
 		url,
 		http.StatusOK,
 		bytes.NewReader(body),
-		&response,
 	)
+	if err != nil {
+		return Release{}, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return Release{}, err
 	}
@@ -182,16 +204,16 @@ func (r ReleasesService) Delete(productSlug string, release Release) error {
 		release.ID,
 	)
 
-	_, _, err := r.client.MakeRequest(
+	resp, err := r.client.MakeRequest(
 		"DELETE",
 		url,
 		http.StatusNoContent,
-		nil,
 		nil,
 	)
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	return nil
 }

--- a/user_groups.go
+++ b/user_groups.go
@@ -65,13 +65,18 @@ func (u UserGroupsService) List() ([]UserGroup, error) {
 	url := "/user_groups"
 
 	var response UserGroupsResponse
-	_, _, err := u.client.MakeRequest(
+	resp, err := u.client.MakeRequest(
 		"GET",
 		url,
 		http.StatusOK,
 		nil,
-		&response,
 	)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return nil, err
 	}
@@ -87,13 +92,18 @@ func (u UserGroupsService) ListForRelease(productSlug string, releaseID int) ([]
 	)
 
 	var response UserGroupsResponse
-	_, _, err := u.client.MakeRequest(
+	resp, err := u.client.MakeRequest(
 		"GET",
 		url,
 		http.StatusOK,
 		nil,
-		&response,
 	)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return nil, err
 	}
@@ -121,16 +131,16 @@ func (u UserGroupsService) AddToRelease(productSlug string, releaseID int, userG
 		return err
 	}
 
-	_, _, err = u.client.MakeRequest(
+	resp, err := u.client.MakeRequest(
 		"PATCH",
 		url,
 		http.StatusNoContent,
 		bytes.NewReader(b),
-		nil,
 	)
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	return nil
 }
@@ -155,16 +165,16 @@ func (u UserGroupsService) RemoveFromRelease(productSlug string, releaseID int, 
 		return err
 	}
 
-	_, _, err = u.client.MakeRequest(
+	resp, err := u.client.MakeRequest(
 		"PATCH",
 		url,
 		http.StatusNoContent,
 		bytes.NewReader(b),
-		nil,
 	)
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	return nil
 }
@@ -173,13 +183,18 @@ func (u UserGroupsService) Get(userGroupID int) (UserGroup, error) {
 	url := fmt.Sprintf("/user_groups/%d", userGroupID)
 
 	var response UserGroup
-	_, _, err := u.client.MakeRequest(
+	resp, err := u.client.MakeRequest(
 		"GET",
 		url,
 		http.StatusOK,
 		nil,
-		&response,
 	)
+	if err != nil {
+		return UserGroup{}, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return UserGroup{}, err
 	}
@@ -212,13 +227,18 @@ func (u UserGroupsService) Create(name string, description string, members []str
 	body := bytes.NewReader(b)
 
 	var response UserGroup
-	_, _, err = u.client.MakeRequest(
+	resp, err := u.client.MakeRequest(
 		"POST",
 		url,
 		http.StatusCreated,
 		body,
-		&response,
 	)
+	if err != nil {
+		return UserGroup{}, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return UserGroup{}, err
 	}
@@ -246,13 +266,18 @@ func (u UserGroupsService) Update(userGroup UserGroup) (UserGroup, error) {
 	body := bytes.NewReader(b)
 
 	var response UpdateUserGroupResponse
-	_, _, err = u.client.MakeRequest(
+	resp, err := u.client.MakeRequest(
 		"PATCH",
 		url,
 		http.StatusOK,
 		body,
-		&response,
 	)
+	if err != nil {
+		return UserGroup{}, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return UserGroup{}, err
 	}
@@ -263,16 +288,16 @@ func (u UserGroupsService) Update(userGroup UserGroup) (UserGroup, error) {
 func (r UserGroupsService) Delete(userGroupID int) error {
 	url := fmt.Sprintf("/user_groups/%d", userGroupID)
 
-	_, _, err := r.client.MakeRequest(
+	resp, err := r.client.MakeRequest(
 		"DELETE",
 		url,
 		http.StatusNoContent,
-		nil,
 		nil,
 	)
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	return nil
 }
@@ -301,13 +326,18 @@ func (r UserGroupsService) AddMemberToGroup(
 	body := bytes.NewReader(b)
 
 	var response UpdateUserGroupResponse
-	_, _, err = r.client.MakeRequest(
+	resp, err := r.client.MakeRequest(
 		"PATCH",
 		url,
 		http.StatusOK,
 		body,
-		&response,
 	)
+	if err != nil {
+		return UserGroup{}, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return UserGroup{}, err
 	}
@@ -334,13 +364,18 @@ func (r UserGroupsService) RemoveMemberFromGroup(userGroupID int, memberEmailAdd
 	body := bytes.NewReader(b)
 
 	var response UpdateUserGroupResponse
-	_, _, err = r.client.MakeRequest(
+	resp, err := r.client.MakeRequest(
 		"PATCH",
 		url,
 		http.StatusOK,
 		body,
-		&response,
 	)
+	if err != nil {
+		return UserGroup{}, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return UserGroup{}, err
 	}


### PR DESCRIPTION
Thank you for contributing to the go-pivnet API library!

- Have you made this pull request to the `develop` branch?
- Have you [run the tests locally](https://github.com/pivotal-cf/go-pivnet#running-the-tests)?

MakeRequest was parsing the entire HTTP response body into memory,
causing out-of-memory problems when downloading large products. This
refactor puts the (small) onus of body parsing on the consuming code,
but adds flexibility to do the right thing with the response.

Signed-off-by: Dan Wendorf <dwendorf@pivotal.io>