### PR TITLE
respect http proxy configured in environment variables

### DIFF
--- a/pivnet.go
+++ b/pivnet.go
@@ -190,6 +190,7 @@ func (c Client) MakeRequest(
 	httpClient = &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: c.skipSSLValidation},
+			Proxy: http.ProxyFromEnvironment,
 		},
 	}
 


### PR DESCRIPTION
Like discussed in the GitHub issue there are no unit tests for this line. And because I've no write access to a PivNet instance the integration tests must be executed. 
