### PR TITLE
Avoid loading downloaded chunks into memory

### DIFF
--- a/download/downloader.go
+++ b/download/downloader.go
@@ -3,7 +3,6 @@ package download
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -63,22 +62,33 @@ func (c Client) Get(
 	c.Bar.Kickoff()
 
 	defer c.Bar.Finish()
+	fileInfo, err := location.Stat()
+	if err != nil {
+		return fmt.Errorf("failed to write file: %s", err)
+	}
 
 	var g errgroup.Group
 	for _, r := range ranges {
 		byteRange := r
+
+		fileWriter, err := os.OpenFile(location.Name(), os.O_RDWR, fileInfo.Mode())
+		if err != nil {
+			return fmt.Errorf("failed to write file: %s", err)
+		}
+
+		_, err = fileWriter.Seek(byteRange.Lower, 0)
+		if err != nil {
+			return fmt.Errorf("failed to write file: %s", err)
+		}
+
 		g.Go(func() error {
-			respBytes, err := c.retryableRequest(contentURL, byteRange.HTTPHeader)
+			err := c.retryableRequest(contentURL, byteRange.HTTPHeader, fileWriter)
 			if err != nil {
 				return fmt.Errorf("failed during retryable request: %s", err)
 			}
 
-			bytesWritten, err := location.WriteAt(respBytes, byteRange.Lower)
-			if err != nil {
-				return fmt.Errorf("failed to write file: %s", err)
-			}
-
-			c.Bar.Add(bytesWritten)
+			bytesWritten := byteRange.Upper - byteRange.Lower + 1
+			c.Bar.Add(int(bytesWritten))
 
 			return nil
 		})
@@ -91,15 +101,17 @@ func (c Client) Get(
 	return nil
 }
 
-func (c Client) retryableRequest(url string, rangeHeader http.Header) ([]byte, error) {
-	req, err := http.NewRequest("GET", url, nil)
+func (c Client) retryableRequest(contentURL string, rangeHeader http.Header, fileWriter *os.File) (error) {
+	currentURL := contentURL
+	defer fileWriter.Close()
+Retry:
+	req, err := http.NewRequest("GET", currentURL, nil)
 	if err != nil {
-		return []byte{}, err
+		return err
 	}
 
 	req.Header = rangeHeader
 
-Retry:
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
 		if netErr, ok := err.(net.Error); ok {
@@ -108,24 +120,22 @@ Retry:
 			}
 		}
 
-		return []byte{}, err
+		return err
 	}
 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusPartialContent {
-		return []byte{}, fmt.Errorf("during GET unexpected status code was returned: %d", resp.StatusCode)
+		return fmt.Errorf("during GET unexpected status code was returned: %d", resp.StatusCode)
 	}
 
-	var respBytes []byte
-	respBytes, err = ioutil.ReadAll(resp.Body)
+	_, err = io.Copy(fileWriter, resp.Body)
 	if err != nil {
 		if err == io.ErrUnexpectedEOF {
 			goto Retry
 		}
-
-		return []byte{}, err
+		return fmt.Errorf("failed to write file: %s", err)
 	}
 
-	return respBytes, err
+	return nil
 }

--- a/download/downloader_test.go
+++ b/download/downloader_test.go
@@ -45,6 +45,8 @@ var _ = Describe("Downloader", func() {
 		httpClient = &fakes.HTTPClient{}
 		ranger = &fakes.Ranger{}
 		bar = &fakes.Bar{}
+
+		bar.NewProxyReaderStub = func(reader io.Reader) (io.Reader) { return reader }
 	})
 
 	Describe("Get", func() {
@@ -138,9 +140,6 @@ var _ = Describe("Downloader", func() {
 			Expect(methods).To(ConsistOf([]string{"HEAD", "GET", "GET"}))
 			Expect(urls).To(ConsistOf([]string{"https://example.com/some-file", "https://example.com/some-file", "https://example.com/some-file"}))
 			Expect(headers).To(ConsistOf([]string{"bytes=0-9", "bytes=10-19"}))
-
-			Expect(bar.AddArgsForCall(0)).To(Equal(10))
-			Expect(bar.AddArgsForCall(1)).To(Equal(10))
 
 			Expect(bar.FinishCallCount()).To(Equal(1))
 		})

--- a/download/downloader_test.go
+++ b/download/downloader_test.go
@@ -327,7 +327,10 @@ var _ = Describe("Downloader", func() {
 					Bar:        bar,
 				}
 
-				err := downloader.Get(nil, "https://example.com/some-file", GinkgoWriter)
+				file, err := ioutil.TempFile("", "")
+				Expect(err).NotTo(HaveOccurred())
+
+				err = downloader.Get(file, "https://example.com/some-file", GinkgoWriter)
 				Expect(err).To(MatchError("failed during retryable request: failed GET"))
 			})
 		})
@@ -364,7 +367,10 @@ var _ = Describe("Downloader", func() {
 					Bar:        bar,
 				}
 
-				err := downloader.Get(nil, "https://example.com/some-file", GinkgoWriter)
+				file, err := ioutil.TempFile("", "")
+				Expect(err).NotTo(HaveOccurred())
+
+				err = downloader.Get(file, "https://example.com/some-file", GinkgoWriter)
 				Expect(err).To(MatchError("failed during retryable request: during GET unexpected status code was returned: 500"))
 			})
 		})

--- a/download/fakes/bar.go
+++ b/download/fakes/bar.go
@@ -25,14 +25,22 @@ type Bar struct {
 	addReturns struct {
 		result1 int
 	}
-	KickoffStub        func()
-	kickoffMutex       sync.RWMutex
-	kickoffArgsForCall []struct{}
-	FinishStub         func()
-	finishMutex        sync.RWMutex
-	finishArgsForCall  []struct{}
-	invocations        map[string][][]interface{}
-	invocationsMutex   sync.RWMutex
+	KickoffStub               func()
+	kickoffMutex              sync.RWMutex
+	kickoffArgsForCall        []struct{}
+	FinishStub                func()
+	finishMutex               sync.RWMutex
+	finishArgsForCall         []struct{}
+	NewProxyReaderStub        func(reader io.Reader) io.Reader
+	newProxyReaderMutex       sync.RWMutex
+	newProxyReaderArgsForCall []struct {
+		reader io.Reader
+	}
+	newProxyReaderReturns struct {
+		result1 io.Reader
+	}
+	invocations      map[string][][]interface{}
+	invocationsMutex sync.RWMutex
 }
 
 func (fake *Bar) SetTotal(contentLength int64) {
@@ -92,9 +100,8 @@ func (fake *Bar) Add(totalWritten int) int {
 	fake.addMutex.Unlock()
 	if fake.AddStub != nil {
 		return fake.AddStub(totalWritten)
-	} else {
-		return fake.addReturns.result1
 	}
+	return fake.addReturns.result1
 }
 
 func (fake *Bar) AddCallCount() int {
@@ -148,6 +155,38 @@ func (fake *Bar) FinishCallCount() int {
 	return len(fake.finishArgsForCall)
 }
 
+func (fake *Bar) NewProxyReader(reader io.Reader) io.Reader {
+	fake.newProxyReaderMutex.Lock()
+	fake.newProxyReaderArgsForCall = append(fake.newProxyReaderArgsForCall, struct {
+		reader io.Reader
+	}{reader})
+	fake.recordInvocation("NewProxyReader", []interface{}{reader})
+	fake.newProxyReaderMutex.Unlock()
+	if fake.NewProxyReaderStub != nil {
+		return fake.NewProxyReaderStub(reader)
+	}
+	return fake.newProxyReaderReturns.result1
+}
+
+func (fake *Bar) NewProxyReaderCallCount() int {
+	fake.newProxyReaderMutex.RLock()
+	defer fake.newProxyReaderMutex.RUnlock()
+	return len(fake.newProxyReaderArgsForCall)
+}
+
+func (fake *Bar) NewProxyReaderArgsForCall(i int) io.Reader {
+	fake.newProxyReaderMutex.RLock()
+	defer fake.newProxyReaderMutex.RUnlock()
+	return fake.newProxyReaderArgsForCall[i].reader
+}
+
+func (fake *Bar) NewProxyReaderReturns(result1 io.Reader) {
+	fake.NewProxyReaderStub = nil
+	fake.newProxyReaderReturns = struct {
+		result1 io.Reader
+	}{result1}
+}
+
 func (fake *Bar) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -161,6 +200,8 @@ func (fake *Bar) Invocations() map[string][][]interface{} {
 	defer fake.kickoffMutex.RUnlock()
 	fake.finishMutex.RLock()
 	defer fake.finishMutex.RUnlock()
+	fake.newProxyReaderMutex.RLock()
+	defer fake.newProxyReaderMutex.RUnlock()
 	return fake.invocations
 }
 

--- a/download/fakes/http_client.go
+++ b/download/fakes/http_client.go
@@ -29,9 +29,8 @@ func (fake *HTTPClient) Do(arg1 *http.Request) (*http.Response, error) {
 	fake.doMutex.Unlock()
 	if fake.DoStub != nil {
 		return fake.DoStub(arg1)
-	} else {
-		return fake.doReturns.result1, fake.doReturns.result2
 	}
+	return fake.doReturns.result1, fake.doReturns.result2
 }
 
 func (fake *HTTPClient) DoCallCount() int {

--- a/download/fakes/ranger.go
+++ b/download/fakes/ranger.go
@@ -30,9 +30,8 @@ func (fake *Ranger) BuildRange(contentLength int64) ([]download.Range, error) {
 	fake.buildRangeMutex.Unlock()
 	if fake.BuildRangeStub != nil {
 		return fake.BuildRangeStub(contentLength)
-	} else {
-		return fake.buildRangeReturns.result1, fake.buildRangeReturns.result2
 	}
+	return fake.buildRangeReturns.result1, fake.buildRangeReturns.result2
 }
 
 func (fake *Ranger) BuildRangeCallCount() int {

--- a/download/progress.go
+++ b/download/progress.go
@@ -28,3 +28,7 @@ func (b Bar) Kickoff() {
 func (b Bar) SetOutput(output io.Writer) {
 	b.Output = output
 }
+
+func (b Bar) NewProxyReader(reader io.Reader) (io.Reader) {
+	return b.ProgressBar.NewProxyReader(reader)
+}


### PR DESCRIPTION
- This behavior was causing swaps.  We now stream the response from our chunk
  requests to the output file.

[#138532779]