### PR TITLE
Use the modified HTTP client rather than the default client

### DIFF
--- a/pivnet.go
+++ b/pivnet.go
@@ -71,7 +71,7 @@ func NewClient(
 
 	ranger := download.NewRanger(concurrentDownloads)
 	downloader := download.Client{
-		HTTPClient: http.DefaultClient,
+		HTTPClient: httpClient,
 		Ranger:     ranger,
 		Logger:     logger,
 	}


### PR DESCRIPTION
In a customer enviornment with a MITM custom-CA TLS authenticated proxy, I noticed that most Pivnet API interactions worked, but downloads returned an x509 error.  

I traced it down to the use of the HTTP DefaultClient which has the default transport in the downloader, rather than the custom client object we just created above.
