### PR TITLE
Handle unknown network errors without segmentation fault

### DIFF
--- a/download/downloader.go
+++ b/download/downloader.go
@@ -160,8 +160,8 @@ Retry:
 			c.Bar.Add(int(-1 * bytesWritten))
 			goto Retry
 		}
-		operr, _ := err.(*net.OpError)
-		if operr.Err.Error() == syscall.ECONNRESET.Error() {
+		operr, ok := err.(*net.OpError)
+		if ok && operr.Err.Error() == syscall.ECONNRESET.Error() {
 			c.Bar.Add(int(-1 * bytesWritten))
 			goto Retry
 		}


### PR DESCRIPTION
Two independent customers with the same MITM HTTP proxy will suddenly terminate the TCP connection while downloading PivNet for unknown reasons (perhaps it thinks there's a virus inside?) .   

This doesn't result in an ECONNRESET or any net.OpError, but some other error code, and the old error handler didn't check for this, resulting in a segfault.  

If you run the unit test in this PR against the old code, i.e.
```
operr, _ := err.(*net.OpError)
	if operr.Err.Error() == syscall.ECONNRESET.Error() {
```
The type assertion fails but we don't check this, and when we dereference operr.Err, a segfault occurs.

```
worlock:go-pivnet stuartcharlton$ cd download
worlock:download stuartcharlton$ 
worlock:download stuartcharlton$  CGO_ENABLED=1 ginkgo \
>     -race \
>     -randomizeAllSpecs \
>     -randomizeSuites \
>     -slowSpecThreshold="40" .
Running Suite: Download Suite
=============================
Random Seed: 1495897436 - Will randomize all specs
Will run 17 of 17 specs

•••••••••••••panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x9b4a2]

goroutine 40 [running]:
panic(0x46af80, 0xc4200100c0)
	/usr/local/Cellar/go/1.7.3/libexec/src/runtime/panic.go:500 +0x1ae
github.com/pivotal-cf/go-pivnet/download.Client.retryableRequest(0x699000, 0xc420389180, 0x699040, 0xc42042e100, 0x69ee00, 0xc420448680, 0x0, 0x0, 0xc42042aa20, 0x1d, ...)
	/Users/stuartcharlton/github/concourse/gopivnet-gopath/src/github.com/pivotal-cf/go-pivnet/download/downloader.go:164 +0x8c2
github.com/pivotal-cf/go-pivnet/download.Client.Get.func1(0x8, 0x506d78)
	/Users/stuartcharlton/github/concourse/gopivnet-gopath/src/github.com/pivotal-cf/go-pivnet/download/downloader.go:92 +0x174
github.com/pivotal-cf/go-pivnet/vendor/golang.org/x/sync/errgroup.(*Group).Go.func1(0xc42042c600, 0xc42042e300)
	/Users/stuartcharlton/github/concourse/gopivnet-gopath/src/github.com/pivotal-cf/go-pivnet/vendor/golang.org/x/sync/errgroup/errgroup.go:58 +0x69
created by github.com/pivotal-cf/go-pivnet/vendor/golang.org/x/sync/errgroup.(*Group).Go
	/Users/stuartcharlton/github/concourse/gopivnet-gopath/src/github.com/pivotal-cf/go-pivnet/vendor/golang.org/x/sync/errgroup/errgroup.go:66 +0x74

Ginkgo ran 1 suite in 1.440593194s
Test Suite Failed
```
The new code prevents this segfault.

Unfortunately it doesn't solve the larger problem of what to do with proxies that like to terminate connections for unknown reasons, which I think would require some kind of capped retries, but I'll experiment with that in a separate PR.