### PR TITLE
the fetch token method is not matching with api https://network.pivot…

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -12,7 +12,7 @@ type AuthService struct {
 }
 
 type UAATokenResponse struct {
-	Token string `json:"token"`
+	Token string `json:"access_token"`
 }
 
 // Check returns:
@@ -47,7 +47,7 @@ func (e AuthService) Check() (bool, error) {
 }
 
 func (e AuthService) FetchUAAToken(refresh_token string) (UAATokenResponse, error) {
-	url := "/authentication"
+	url := "/authentication/access_tokens"
 
 	body := AuthBody{RefreshToken: refresh_token}
 	b, err := json.Marshal(body)

--- a/auth_test.go
+++ b/auth_test.go
@@ -150,7 +150,7 @@ var _ = Describe("PivnetClient - Auth", func() {
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("POST", fmt.Sprintf(
-						"%s/authentication",
+						"%s/authentication/access_tokens",
 						apiPrefix,
 					)),
 					ghttp.VerifyJSON(expectedRequestBody),
@@ -175,7 +175,7 @@ var _ = Describe("PivnetClient - Auth", func() {
 				server.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("POST", fmt.Sprintf(
-							"%s/authentication",
+							"%s/authentication/access_tokens",
 							apiPrefix,
 						)),
 						ghttp.VerifyJSON(expectedRequestBody),


### PR DESCRIPTION
POST /api/v2/authentication/access_tokens HTTP/1.1
Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
Content-Length: 26
Content-Type: application/x-www-form-urlencoded
Host: www.example.com


{"refresh_token":"abc123"}
Response
HTTP/1.1 200
Cache-Control: max-age=0, private, must-revalidate
Content-Length: 25
Content-Type: application/json; charset=utf-8
ETag: W/"dcd9e9446ed27172c3eff227246daeef"
Vary: Accept-Encoding


{
  "access_token": "xyz890"
}


Thank you for contributing to the go-pivnet API library!

- Have you made this pull request to the `develop` branch?
You do not even have a develop branch
- Have you [run the tests locally](https://github.com/pivotal-cf/go-pivnet#running-the-tests)?
Yes
