### PR TITLE
replaced crypto/sha256 with github.com/minio/sha256-simd.

### DIFF
--- a/md5sum/md5_test.go
+++ b/md5sum/md5_test.go
@@ -7,7 +7,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/pivnet-resource/md5sum"
+	"github.com/pivotal-cf/go-pivnet/md5sum"
 )
 
 var _ = Describe("MD5", func() {

--- a/sha256sum/sha256.go
+++ b/sha256sum/sha256.go
@@ -1,8 +1,8 @@
 package sha256sum
 
 import (
-	"crypto/sha256"
 	"fmt"
+	"github.com/minio/sha256-simd"
 	"io"
 	"os"
 )

--- a/sha256sum/sha256_test.go
+++ b/sha256sum/sha256_test.go
@@ -7,7 +7,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/pivnet-resource/sha256sum"
+	"github.com/pivotal-cf/go-pivnet/sha256sum"
 )
 
 var _ = Describe("SHA256", func() {


### PR DESCRIPTION
minio/sha256-simd is significantly faster than crypto/sha256 as it uses native processor primitives in assembly instead of a pure golang implementation. it supports both Intel and ARM, and will default to crypto/sha256 for AMD processors.

this change comes as large binary downloads, such as pas/srt, take a significantly long time to checksum, and this change will save large chunks of time when it comes to levering upstream tools such as pivnet-cli.

there were two stale references to the pivnet-resource in the sha256 and md5 implementations, those were updated to reference their formal implementations since the dependent libraries no longer exist.

Signed-off-by: Mike Lloyd <mlloyd@pivotal.io>
