### PR TITLE
Panic instead of exit, so we can recover and retry

### DIFF
--- a/pivnet.go
+++ b/pivnet.go
@@ -64,7 +64,7 @@ func (o AccessTokenOrLegacyToken) AccessToken() (string, error) {
 
 		accessToken, err := tokenFetcher.GetToken()
 		if err != nil {
-			log.Fatalf("Exiting with error: %s", err)
+			log.Panicf("Exiting with error: %s", err)
 			return "", err
 		}
 		return accessToken, nil


### PR DESCRIPTION
We are using `go-pivnet` to automate installs of PAS using [om-tiler](https://github.com/starkandwayne/om-tiler). The payload which drives these installs is a single go binary, which has retry logic build in. However as of lately we often have customers complain about stalled installs. After investigation we found the root cause to be related to the use of `log.Fatalf` in the `go-pivnet` library. Since `log.Fatalf` calls `os.exit(1)` which gives us not way to recover.

Switching to `log.Panicf` will allow us to use `recover` to retry temporary issues. The error we are facing is:
```
2019/06/22 13:09:27 Exiting with error: API token request failed: Post https://network.pivotal.io/api/v2/authentication/access_tokens: dial tcp: i/o timeout
```

Which should be fine to retry.

