### PR TITLE
extend timeouts on http operations

### DIFF
--- a/pivnet.go
+++ b/pivnet.go
@@ -60,7 +60,7 @@ type AccessTokenOrLegacyToken struct {
 }
 
 type QueryParameter struct {
-	Key string
+	Key   string
 	Value string
 }
 
@@ -122,7 +122,7 @@ func NewClient(
 	baseURL := fmt.Sprintf("%s%s", config.Host, apiVersion)
 
 	httpClient := &http.Client{
-		Timeout: 60 * time.Second,
+		Timeout: 10 * time.Minute,
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: config.SkipSSLValidation,
@@ -146,7 +146,7 @@ func NewClient(
 		HTTPClient: downloadClient,
 		Ranger:     ranger,
 		Logger:     logger,
-		Timeout:    5 * time.Second,
+		Timeout:    60 * time.Second,
 	}
 
 	client := Client{


### PR DESCRIPTION
This change addresses https://github.com/pivotal-cf/pivnet-resource/issues/129

We have some operations against pivnet that consistently take a couple of minutes, so failing after 1 minute of waiting causes blocking issues in our pipelines.

CC @angelachin

------

Thank you for contributing to the go-pivnet API library!

- Have you made this pull request to the `develop` branch?
  The develop branch does not appear to exist.
- Have you [run the tests locally](https://github.com/pivotal-cf/go-pivnet#running-the-tests)?
  We ran the units.
