### PR TITLE
update module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ See [example](https://github.com/pivotal-cf/go-pivnet/blob/master/example/main.g
 for an executable example.
 
 ```go
-import pivnet github.com/pivotal-cf/go-pivnet/v7
+import pivnet github.com/pivotal-cf/go-pivnet/v9
 
 [...]
 

--- a/artifact_references_test.go
+++ b/artifact_references_test.go
@@ -2,12 +2,14 @@ package pivnet_test
 
 import (
 	"fmt"
-	"github.com/onsi/gomega/ghttp"
-	"github.com/pivotal-cf/go-pivnet/v7"
-	"github.com/pivotal-cf/go-pivnet/v7/go-pivnetfakes"
-	"github.com/pivotal-cf/go-pivnet/v7/logger"
-	"github.com/pivotal-cf/go-pivnet/v7/logger/loggerfakes"
 	"net/http"
+
+	"github.com/onsi/gomega/ghttp"
+
+	"github.com/pivotal-cf/go-pivnet/v9"
+	"github.com/pivotal-cf/go-pivnet/v9/go-pivnetfakes"
+	"github.com/pivotal-cf/go-pivnet/v9/logger"
+	"github.com/pivotal-cf/go-pivnet/v9/logger/loggerfakes"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -145,9 +147,9 @@ var _ = Describe("PivnetClient - artifact references", func() {
 					Name: "something",
 				},
 				{
-					ID:   2345,
-					Name: "something-else",
-					ReleaseVersions: []string{"1.0.0","1.2.3"},
+					ID:              2345,
+					Name:            "something-else",
+					ReleaseVersions: []string{"1.0.0", "1.2.3"},
 				},
 			}}
 

--- a/auth_test.go
+++ b/auth_test.go
@@ -5,9 +5,10 @@ import (
 	"net/http"
 
 	"github.com/onsi/gomega/ghttp"
-	"github.com/pivotal-cf/go-pivnet/v7"
-	"github.com/pivotal-cf/go-pivnet/v7/logger"
-	"github.com/pivotal-cf/go-pivnet/v7/logger/loggerfakes"
+
+	"github.com/pivotal-cf/go-pivnet/v9"
+	"github.com/pivotal-cf/go-pivnet/v9/logger"
+	"github.com/pivotal-cf/go-pivnet/v9/logger/loggerfakes"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/dependency_specifiers_test.go
+++ b/dependency_specifiers_test.go
@@ -2,13 +2,15 @@ package pivnet_test
 
 import (
 	"fmt"
-	"github.com/pivotal-cf/go-pivnet/v7/go-pivnetfakes"
 	"net/http"
 
+	"github.com/pivotal-cf/go-pivnet/v9/go-pivnetfakes"
+
 	"github.com/onsi/gomega/ghttp"
-	"github.com/pivotal-cf/go-pivnet/v7"
-	"github.com/pivotal-cf/go-pivnet/v7/logger"
-	"github.com/pivotal-cf/go-pivnet/v7/logger/loggerfakes"
+
+	"github.com/pivotal-cf/go-pivnet/v9"
+	"github.com/pivotal-cf/go-pivnet/v9/logger"
+	"github.com/pivotal-cf/go-pivnet/v9/logger/loggerfakes"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/download/downloader.go
+++ b/download/downloader.go
@@ -15,7 +15,7 @@ import (
 	"github.com/shirou/gopsutil/disk"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/pivotal-cf/go-pivnet/v7/logger"
+	"github.com/pivotal-cf/go-pivnet/v9/logger"
 )
 
 //go:generate counterfeiter -o ./fakes/ranger.go --fake-name Ranger . ranger

--- a/download/downloader_test.go
+++ b/download/downloader_test.go
@@ -2,26 +2,26 @@ package download_test
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
-	"net/http"
-	"net/url"
-	"strings"
-	"sync"
-
-	"github.com/pivotal-cf/go-pivnet/v7/download"
-	"github.com/pivotal-cf/go-pivnet/v7/download/fakes"
-
-	"fmt"
 	"math"
 	"net"
+	"net/http"
+	"net/url"
 	"os"
+	"strings"
+	"sync"
 	"syscall"
 	"time"
 
+	"github.com/pivotal-cf/go-pivnet/v9/download"
+	"github.com/pivotal-cf/go-pivnet/v9/download/fakes"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/go-pivnet/v7/logger/loggerfakes"
+
+	"github.com/pivotal-cf/go-pivnet/v9/logger/loggerfakes"
 )
 
 type EOFReader struct{}

--- a/download/fakes/ranger.go
+++ b/download/fakes/ranger.go
@@ -4,7 +4,7 @@ package fakes
 import (
 	"sync"
 
-	"github.com/pivotal-cf/go-pivnet/v7/download"
+	"github.com/pivotal-cf/go-pivnet/v9/download"
 )
 
 type Ranger struct {

--- a/download/progress_test.go
+++ b/download/progress_test.go
@@ -6,7 +6,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
-	"github.com/pivotal-cf/go-pivnet/v7/download"
+	"github.com/pivotal-cf/go-pivnet/v9/download"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/download/ranger_test.go
+++ b/download/ranger_test.go
@@ -3,7 +3,7 @@ package download_test
 import (
 	"net/http"
 
-	"github.com/pivotal-cf/go-pivnet/v7/download"
+	"github.com/pivotal-cf/go-pivnet/v9/download"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/eulas_test.go
+++ b/eulas_test.go
@@ -2,13 +2,15 @@ package pivnet_test
 
 import (
 	"fmt"
-	"github.com/pivotal-cf/go-pivnet/v7/go-pivnetfakes"
 	"net/http"
 
+	"github.com/pivotal-cf/go-pivnet/v9/go-pivnetfakes"
+
 	"github.com/onsi/gomega/ghttp"
-	"github.com/pivotal-cf/go-pivnet/v7"
-	"github.com/pivotal-cf/go-pivnet/v7/logger"
-	"github.com/pivotal-cf/go-pivnet/v7/logger/loggerfakes"
+
+	"github.com/pivotal-cf/go-pivnet/v9"
+	"github.com/pivotal-cf/go-pivnet/v9/logger"
+	"github.com/pivotal-cf/go-pivnet/v9/logger/loggerfakes"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/example/main.go
+++ b/example/main.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"os"
 
-	pivnet "github.com/pivotal-cf/go-pivnet/v7"
-	"github.com/pivotal-cf/go-pivnet/v7/logshim"
+	pivnet "github.com/pivotal-cf/go-pivnet/v9"
+	"github.com/pivotal-cf/go-pivnet/v9/logshim"
 )
 
 func main() {

--- a/example/proxy_basic_auth.go
+++ b/example/proxy_basic_auth.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"os"
 
-	pivnet "github.com/pivotal-cf/go-pivnet/v7"
-	"github.com/pivotal-cf/go-pivnet/v7/logshim"
+	pivnet "github.com/pivotal-cf/go-pivnet/v9"
+	"github.com/pivotal-cf/go-pivnet/v9/logshim"
 )
 
 // Example demonstrating HTTP Basic proxy authentication

--- a/example/proxy_spnego_auth.go
+++ b/example/proxy_spnego_auth.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"os"
 
-	pivnet "github.com/pivotal-cf/go-pivnet/v7"
-	"github.com/pivotal-cf/go-pivnet/v7/logshim"
+	pivnet "github.com/pivotal-cf/go-pivnet/v9"
+	"github.com/pivotal-cf/go-pivnet/v9/logshim"
 )
 
 // Example demonstrating Kerberos/SPNEGO proxy authentication

--- a/federation_token_test.go
+++ b/federation_token_test.go
@@ -2,13 +2,15 @@ package pivnet_test
 
 import (
 	"fmt"
-	"github.com/pivotal-cf/go-pivnet/v7/go-pivnetfakes"
 	"net/http"
 
+	"github.com/pivotal-cf/go-pivnet/v9/go-pivnetfakes"
+
 	"github.com/onsi/gomega/ghttp"
-	"github.com/pivotal-cf/go-pivnet/v7"
-	"github.com/pivotal-cf/go-pivnet/v7/logger"
-	"github.com/pivotal-cf/go-pivnet/v7/logger/loggerfakes"
+
+	"github.com/pivotal-cf/go-pivnet/v9"
+	"github.com/pivotal-cf/go-pivnet/v9/logger"
+	"github.com/pivotal-cf/go-pivnet/v9/logger/loggerfakes"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/file_groups_test.go
+++ b/file_groups_test.go
@@ -2,13 +2,15 @@ package pivnet_test
 
 import (
 	"fmt"
-	"github.com/pivotal-cf/go-pivnet/v7/go-pivnetfakes"
 	"net/http"
 
+	"github.com/pivotal-cf/go-pivnet/v9/go-pivnetfakes"
+
 	"github.com/onsi/gomega/ghttp"
-	"github.com/pivotal-cf/go-pivnet/v7"
-	"github.com/pivotal-cf/go-pivnet/v7/logger"
-	"github.com/pivotal-cf/go-pivnet/v7/logger/loggerfakes"
+
+	"github.com/pivotal-cf/go-pivnet/v9"
+	"github.com/pivotal-cf/go-pivnet/v9/logger"
+	"github.com/pivotal-cf/go-pivnet/v9/logger/loggerfakes"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/go-pivnetfakes/fake_access_token_service.go
+++ b/go-pivnetfakes/fake_access_token_service.go
@@ -4,7 +4,7 @@ package gopivnetfakes
 import (
 	"sync"
 
-	pivnet "github.com/pivotal-cf/go-pivnet/v7"
+	pivnet "github.com/pivotal-cf/go-pivnet/v9"
 )
 
 type FakeAccessTokenService struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pivotal-cf/go-pivnet/v7
+module github.com/pivotal-cf/go-pivnet/v9
 
 go 1.16
 

--- a/integration/dependency_specifiers_test.go
+++ b/integration/dependency_specifiers_test.go
@@ -3,7 +3,8 @@ package integration_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	pivnet "github.com/pivotal-cf/go-pivnet/v7"
+
+	pivnet "github.com/pivotal-cf/go-pivnet/v9"
 )
 
 const (

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -3,15 +3,15 @@ package integration_test
 import (
 	"fmt"
 	"os"
+	"testing"
 
-	"github.com/pivotal-cf/go-pivnet/v7"
-	"github.com/pivotal-cf/go-pivnet/v7/logger"
 	"github.com/robdimsdale/sanitizer"
+
+	"github.com/pivotal-cf/go-pivnet/v9"
+	"github.com/pivotal-cf/go-pivnet/v9/logger"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 const testProductSlug = "pivnet-resource-test"

--- a/integration/products_lifecycle_test.go
+++ b/integration/products_lifecycle_test.go
@@ -3,7 +3,8 @@ package integration_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/go-pivnet/v7"
+
+	"github.com/pivotal-cf/go-pivnet/v9"
 )
 
 var _ = Describe("Products Lifecycle", func() {

--- a/integration/upgrade_path_specifiers_test.go
+++ b/integration/upgrade_path_specifiers_test.go
@@ -3,7 +3,8 @@ package integration_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	pivnet "github.com/pivotal-cf/go-pivnet/v7"
+
+	pivnet "github.com/pivotal-cf/go-pivnet/v9"
 )
 
 const (

--- a/logger/loggerfakes/fake_logger.go
+++ b/logger/loggerfakes/fake_logger.go
@@ -4,7 +4,7 @@ package loggerfakes
 import (
 	"sync"
 
-	"github.com/pivotal-cf/go-pivnet/v7/logger"
+	"github.com/pivotal-cf/go-pivnet/v9/logger"
 )
 
 type FakeLogger struct {

--- a/logshim/logshim.go
+++ b/logshim/logshim.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/pivotal-cf/go-pivnet/v7/logger"
+	"github.com/pivotal-cf/go-pivnet/v9/logger"
 )
 
 type LogShim struct {

--- a/md5sum/md5_test.go
+++ b/md5sum/md5_test.go
@@ -7,7 +7,8 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/go-pivnet/v7/md5sum"
+
+	"github.com/pivotal-cf/go-pivnet/v9/md5sum"
 )
 
 var _ = Describe("MD5", func() {
@@ -16,7 +17,7 @@ var _ = Describe("MD5", func() {
 			tempFilePath string
 			tempDir      string
 			fileContents []byte
-			fileSummer *md5sum.FileSummer
+			fileSummer   *md5sum.FileSummer
 		)
 
 		BeforeEach(func() {

--- a/pivnet.go
+++ b/pivnet.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pivotal-cf/go-pivnet/v7/download"
-	"github.com/pivotal-cf/go-pivnet/v7/logger"
+	"github.com/pivotal-cf/go-pivnet/v9/download"
+	"github.com/pivotal-cf/go-pivnet/v9/logger"
 )
 
 const (

--- a/pivnet_test.go
+++ b/pivnet_test.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"net/http"
 
-	gopivnetfakes "github.com/pivotal-cf/go-pivnet/v7/go-pivnetfakes"
+	gopivnetfakes "github.com/pivotal-cf/go-pivnet/v9/go-pivnetfakes"
 
 	"github.com/onsi/gomega/ghttp"
 
-	"github.com/pivotal-cf/go-pivnet/v7"
-	"github.com/pivotal-cf/go-pivnet/v7/logger"
-	"github.com/pivotal-cf/go-pivnet/v7/logger/loggerfakes"
+	"github.com/pivotal-cf/go-pivnet/v9"
+	"github.com/pivotal-cf/go-pivnet/v9/logger"
+	"github.com/pivotal-cf/go-pivnet/v9/logger/loggerfakes"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/pivnet_versions_test.go
+++ b/pivnet_versions_test.go
@@ -2,13 +2,15 @@ package pivnet_test
 
 import (
 	"fmt"
-	"github.com/pivotal-cf/go-pivnet/v7/go-pivnetfakes"
 	"net/http"
 
+	"github.com/pivotal-cf/go-pivnet/v9/go-pivnetfakes"
+
 	"github.com/onsi/gomega/ghttp"
-	"github.com/pivotal-cf/go-pivnet/v7"
-	"github.com/pivotal-cf/go-pivnet/v7/logger"
-	"github.com/pivotal-cf/go-pivnet/v7/logger/loggerfakes"
+
+	"github.com/pivotal-cf/go-pivnet/v9"
+	"github.com/pivotal-cf/go-pivnet/v9/logger"
+	"github.com/pivotal-cf/go-pivnet/v9/logger/loggerfakes"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -46,8 +48,8 @@ var _ = Describe("PivnetClient - pivnet versions", func() {
 
 	Describe("List", func() {
 		var (
-			pivnetResourceVersion  = "7.8.9"
-			pivnetCliVersion       = "2.3.4"
+			pivnetResourceVersion = "7.8.9"
+			pivnetCliVersion      = "2.3.4"
 		)
 
 		Context("valid requests", func() {

--- a/product_file_link_fetcher_test.go
+++ b/product_file_link_fetcher_test.go
@@ -1,14 +1,16 @@
 package pivnet_test
 
 import (
-	"github.com/onsi/gomega/ghttp"
-	"github.com/pivotal-cf/go-pivnet/v7"
-	"github.com/pivotal-cf/go-pivnet/v7/go-pivnetfakes"
-	"github.com/pivotal-cf/go-pivnet/v7/logger"
-	"github.com/pivotal-cf/go-pivnet/v7/logger/loggerfakes"
+	"fmt"
 	"net/http"
 
-	"fmt"
+	"github.com/onsi/gomega/ghttp"
+
+	"github.com/pivotal-cf/go-pivnet/v9"
+	"github.com/pivotal-cf/go-pivnet/v9/go-pivnetfakes"
+	"github.com/pivotal-cf/go-pivnet/v9/logger"
+	"github.com/pivotal-cf/go-pivnet/v9/logger/loggerfakes"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/product_files.go
+++ b/product_files.go
@@ -7,8 +7,8 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/pivotal-cf/go-pivnet/v7/download"
-	"github.com/pivotal-cf/go-pivnet/v7/logger"
+	"github.com/pivotal-cf/go-pivnet/v9/download"
+	"github.com/pivotal-cf/go-pivnet/v9/logger"
 )
 
 type ProductFilesService struct {

--- a/product_files_test.go
+++ b/product_files_test.go
@@ -2,20 +2,23 @@ package pivnet_test
 
 import (
 	"fmt"
-	"github.com/pivotal-cf/go-pivnet/v7/go-pivnetfakes"
 	"io/ioutil"
 	"net/http"
 	"regexp"
 	"strconv"
 
+	"github.com/pivotal-cf/go-pivnet/v9/go-pivnetfakes"
+
 	"github.com/onsi/gomega/ghttp"
-	"github.com/pivotal-cf/go-pivnet/v7"
-	"github.com/pivotal-cf/go-pivnet/v7/logger"
-	"github.com/pivotal-cf/go-pivnet/v7/logger/loggerfakes"
+
+	"github.com/pivotal-cf/go-pivnet/v9"
+	"github.com/pivotal-cf/go-pivnet/v9/logger"
+	"github.com/pivotal-cf/go-pivnet/v9/logger/loggerfakes"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/go-pivnet/v7/download"
+
+	"github.com/pivotal-cf/go-pivnet/v9/download"
 )
 
 var _ = Describe("PivnetClient - product files", func() {
@@ -667,7 +670,7 @@ var _ = Describe("PivnetClient - product files", func() {
 				)
 
 				_, err := client.ProductFiles.Update(productSlug, productFile)
-				
+
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("foo message"))
 			})

--- a/products.go
+++ b/products.go
@@ -1,11 +1,11 @@
 package pivnet
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 
-	"encoding/json"
-	"github.com/pivotal-cf/go-pivnet/v7/logger"
+	"github.com/pivotal-cf/go-pivnet/v9/logger"
 )
 
 type ProductsService struct {

--- a/products_test.go
+++ b/products_test.go
@@ -2,13 +2,15 @@ package pivnet_test
 
 import (
 	"fmt"
-	"github.com/pivotal-cf/go-pivnet/v7/go-pivnetfakes"
 	"net/http"
 
+	"github.com/pivotal-cf/go-pivnet/v9/go-pivnetfakes"
+
 	"github.com/onsi/gomega/ghttp"
-	"github.com/pivotal-cf/go-pivnet/v7"
-	"github.com/pivotal-cf/go-pivnet/v7/logger"
-	"github.com/pivotal-cf/go-pivnet/v7/logger/loggerfakes"
+
+	"github.com/pivotal-cf/go-pivnet/v9"
+	"github.com/pivotal-cf/go-pivnet/v9/logger"
+	"github.com/pivotal-cf/go-pivnet/v9/logger/loggerfakes"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -236,7 +238,7 @@ var _ = Describe("PivnetClient - product", func() {
 	Describe("SlugAlias", func() {
 		Context("when product can be found", func() {
 			var (
-				productSlug = "product-slug"
+				productSlug      = "product-slug"
 				productSlugAlias = "product-slug-alias"
 			)
 

--- a/proxy_auth_basic_test.go
+++ b/proxy_auth_basic_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	pivnet "github.com/pivotal-cf/go-pivnet/v7"
+	pivnet "github.com/pivotal-cf/go-pivnet/v9"
 )
 
 func TestNewBasicProxyAuth(t *testing.T) {

--- a/proxy_auth_spnego_test.go
+++ b/proxy_auth_spnego_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	pivnet "github.com/pivotal-cf/go-pivnet/v7"
+	pivnet "github.com/pivotal-cf/go-pivnet/v9"
 )
 
 func TestNewSPNEGOProxyAuth(t *testing.T) {

--- a/proxy_auth_test.go
+++ b/proxy_auth_test.go
@@ -8,7 +8,7 @@ import (
 	"net/url"
 	"testing"
 
-	pivnet "github.com/pivotal-cf/go-pivnet/v7"
+	pivnet "github.com/pivotal-cf/go-pivnet/v9"
 )
 
 // mockAuthenticator is a mock implementation of ProxyAuthenticator for testing

--- a/proxy_authenticator_test.go
+++ b/proxy_authenticator_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	pivnet "github.com/pivotal-cf/go-pivnet/v7"
+	pivnet "github.com/pivotal-cf/go-pivnet/v9"
 )
 
 func TestNewProxyAuthenticator(t *testing.T) {

--- a/release_dependencies_test.go
+++ b/release_dependencies_test.go
@@ -2,13 +2,15 @@ package pivnet_test
 
 import (
 	"fmt"
-	"github.com/pivotal-cf/go-pivnet/v7/go-pivnetfakes"
 	"net/http"
 
+	"github.com/pivotal-cf/go-pivnet/v9/go-pivnetfakes"
+
 	"github.com/onsi/gomega/ghttp"
-	"github.com/pivotal-cf/go-pivnet/v7"
-	"github.com/pivotal-cf/go-pivnet/v7/logger"
-	"github.com/pivotal-cf/go-pivnet/v7/logger/loggerfakes"
+
+	"github.com/pivotal-cf/go-pivnet/v9"
+	"github.com/pivotal-cf/go-pivnet/v9/logger"
+	"github.com/pivotal-cf/go-pivnet/v9/logger/loggerfakes"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/release_types_test.go
+++ b/release_types_test.go
@@ -2,13 +2,15 @@ package pivnet_test
 
 import (
 	"fmt"
-	"github.com/pivotal-cf/go-pivnet/v7/go-pivnetfakes"
 	"net/http"
 
+	"github.com/pivotal-cf/go-pivnet/v9/go-pivnetfakes"
+
 	"github.com/onsi/gomega/ghttp"
-	"github.com/pivotal-cf/go-pivnet/v7"
-	"github.com/pivotal-cf/go-pivnet/v7/logger"
-	"github.com/pivotal-cf/go-pivnet/v7/logger/loggerfakes"
+
+	"github.com/pivotal-cf/go-pivnet/v9"
+	"github.com/pivotal-cf/go-pivnet/v9/logger"
+	"github.com/pivotal-cf/go-pivnet/v9/logger/loggerfakes"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/release_upgrade_paths_test.go
+++ b/release_upgrade_paths_test.go
@@ -2,13 +2,15 @@ package pivnet_test
 
 import (
 	"fmt"
-	"github.com/pivotal-cf/go-pivnet/v7/go-pivnetfakes"
 	"net/http"
 
+	"github.com/pivotal-cf/go-pivnet/v9/go-pivnetfakes"
+
 	"github.com/onsi/gomega/ghttp"
-	"github.com/pivotal-cf/go-pivnet/v7"
-	"github.com/pivotal-cf/go-pivnet/v7/logger"
-	"github.com/pivotal-cf/go-pivnet/v7/logger/loggerfakes"
+
+	"github.com/pivotal-cf/go-pivnet/v9"
+	"github.com/pivotal-cf/go-pivnet/v9/logger"
+	"github.com/pivotal-cf/go-pivnet/v9/logger/loggerfakes"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/releases.go
+++ b/releases.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/pivotal-cf/go-pivnet/v7/logger"
+	"github.com/pivotal-cf/go-pivnet/v9/logger"
 )
 
 type ReleasesService struct {

--- a/releases_test.go
+++ b/releases_test.go
@@ -2,14 +2,16 @@ package pivnet_test
 
 import (
 	"fmt"
-	"github.com/pivotal-cf/go-pivnet/v7/go-pivnetfakes"
 	"net/http"
 	"time"
 
+	"github.com/pivotal-cf/go-pivnet/v9/go-pivnetfakes"
+
 	"github.com/onsi/gomega/ghttp"
-	"github.com/pivotal-cf/go-pivnet/v7"
-	"github.com/pivotal-cf/go-pivnet/v7/logger"
-	"github.com/pivotal-cf/go-pivnet/v7/logger/loggerfakes"
+
+	"github.com/pivotal-cf/go-pivnet/v9"
+	"github.com/pivotal-cf/go-pivnet/v9/logger"
+	"github.com/pivotal-cf/go-pivnet/v9/logger/loggerfakes"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -22,8 +24,8 @@ var _ = Describe("PivnetClient - product files", func() {
 		apiAddress string
 		userAgent  string
 
-		newClientConfig pivnet.ClientConfig
-		fakeLogger      logger.Logger
+		newClientConfig        pivnet.ClientConfig
+		fakeLogger             logger.Logger
 		fakeAccessTokenService *gopivnetfakes.FakeAccessTokenService
 	)
 

--- a/sha256sum/sha256_test.go
+++ b/sha256sum/sha256_test.go
@@ -7,7 +7,8 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/go-pivnet/v7/sha256sum"
+
+	"github.com/pivotal-cf/go-pivnet/v9/sha256sum"
 )
 
 var _ = Describe("SHA256", func() {

--- a/subscription_groups_test.go
+++ b/subscription_groups_test.go
@@ -2,13 +2,15 @@ package pivnet_test
 
 import (
 	"fmt"
-	"github.com/pivotal-cf/go-pivnet/v7/go-pivnetfakes"
 	"net/http"
 
+	"github.com/pivotal-cf/go-pivnet/v9/go-pivnetfakes"
+
 	"github.com/onsi/gomega/ghttp"
-	"github.com/pivotal-cf/go-pivnet/v7"
-	"github.com/pivotal-cf/go-pivnet/v7/logger"
-	"github.com/pivotal-cf/go-pivnet/v7/logger/loggerfakes"
+
+	"github.com/pivotal-cf/go-pivnet/v9"
+	"github.com/pivotal-cf/go-pivnet/v9/logger"
+	"github.com/pivotal-cf/go-pivnet/v9/logger/loggerfakes"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/upgrade_path_specifiers_test.go
+++ b/upgrade_path_specifiers_test.go
@@ -2,13 +2,15 @@ package pivnet_test
 
 import (
 	"fmt"
-	"github.com/pivotal-cf/go-pivnet/v7/go-pivnetfakes"
 	"net/http"
 
+	"github.com/pivotal-cf/go-pivnet/v9/go-pivnetfakes"
+
 	"github.com/onsi/gomega/ghttp"
-	"github.com/pivotal-cf/go-pivnet/v7"
-	"github.com/pivotal-cf/go-pivnet/v7/logger"
-	"github.com/pivotal-cf/go-pivnet/v7/logger/loggerfakes"
+
+	"github.com/pivotal-cf/go-pivnet/v9"
+	"github.com/pivotal-cf/go-pivnet/v9/logger"
+	"github.com/pivotal-cf/go-pivnet/v9/logger/loggerfakes"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/user_groups_test.go
+++ b/user_groups_test.go
@@ -2,13 +2,15 @@ package pivnet_test
 
 import (
 	"fmt"
-	"github.com/pivotal-cf/go-pivnet/v7/go-pivnetfakes"
 	"net/http"
 
+	"github.com/pivotal-cf/go-pivnet/v9/go-pivnetfakes"
+
 	"github.com/onsi/gomega/ghttp"
-	"github.com/pivotal-cf/go-pivnet/v7"
-	"github.com/pivotal-cf/go-pivnet/v7/logger"
-	"github.com/pivotal-cf/go-pivnet/v7/logger/loggerfakes"
+
+	"github.com/pivotal-cf/go-pivnet/v9"
+	"github.com/pivotal-cf/go-pivnet/v9/logger"
+	"github.com/pivotal-cf/go-pivnet/v9/logger/loggerfakes"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"


### PR DESCRIPTION
This PR updates the go-pivnet module name to github.com/pivotal-cf/go-pivnet/v9